### PR TITLE
Code review overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,6 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "futures",
  "is-terminal",
  "itertools",
  "num-traits",
@@ -350,7 +349,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
- "tokio",
  "walkdir",
 ]
 
@@ -544,66 +542,6 @@ name = "fsum"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5f673e5179fc055a5cb48fb40fc3f317160598d60c93b0ef8173504117765b0"
-
-[[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-sink",
- "futures-task",
- "pin-project-lite",
-]
 
 [[package]]
 name = "generic-tests"
@@ -1233,12 +1171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,15 +1780,6 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "tokio"
-version = "1.52.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
-dependencies = [
- "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -61,9 +61,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -76,44 +76,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
@@ -123,9 +123,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -133,8 +133,23 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "binout"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222fb4925a15bea6a68075021910e03d6aa2d04951d71ff1d956190a551d738f"
 
 [[package]]
 name = "bitflags"
@@ -144,9 +159,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitset-core"
@@ -156,15 +171,15 @@ checksum = "f421f1bcb30aa9d851a03c2920ab5d96ca920d5786645a597b5fc37922f8b89e"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytesize"
-version = "2.0.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cast"
@@ -174,9 +189,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -184,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "ciborium"
@@ -217,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -237,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -249,42 +264,58 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.45",
  "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "co_sort"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc18e115ded94ba1e1b820c7631d25b7364e27c25f066ecbce37aaf88abdcf4"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -388,6 +419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn_size_of"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a742b95783b1f45b900129082cbc47717b6a77ee8d17eea70a8ea62462f5de3"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,9 +432,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -405,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -432,7 +469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.45",
  "syn",
 ]
 
@@ -449,20 +486,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "findshlibs"
@@ -477,10 +514,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fsum"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f673e5179fc055a5cb48fb40fc3f317160598d60c93b0ef8173504117765b0"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -492,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -502,67 +551,106 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
+]
+
+[[package]]
+name = "generic-tests"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ff6d6584f4f6fa911d5e07856abf1a48dc5599b3734f2eaea130f2c3baa989"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -580,24 +668,41 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hdt"
-version = "0.5.0"
-source = "git+https://github.com/KonradHoeffner/hdt/?tag=0.5.0#26c889078b2dc9954db1cbdc635677fc3ff223e8"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2b1ea7cbd25071f796251a1081ded2a164dd24e034d5f75342da35c157cf4e"
 dependencies = [
  "bitset-core",
  "bytesize",
+ "console_error_panic_hook",
  "crc",
  "env_logger",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "lasso",
  "log",
+ "mem_dbg",
  "mownstr",
  "ntriple",
  "oxttl",
+ "qwt",
  "rayon",
- "sucds",
- "thiserror 2.0.16",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -614,50 +719,47 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "libc",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -670,39 +772,39 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.45",
  "syn",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -710,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "json-event-parser"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73267b6bffa5356bd46cfa89386673e9a7f62f4eb3adcb45b1bd031892357853"
+checksum = "574b0cd5e90ee2ba03a66d0611fc9a09c9a0c28b2ecc2dc8a181dd31a53ca5d7"
 
 [[package]]
 name = "lasso"
@@ -731,10 +833,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.175"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -744,39 +852,71 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mem_dbg"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728cc9dc97593cd22f7bc81fbef70a2d391d7a9a855e7d658b653318124a6cf0"
+dependencies = [
+ "bitflags 2.11.1",
+ "mem_dbg-derive",
+]
+
+[[package]]
+name = "mem_dbg-derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84f40c93b0508d5565db79a814d02d5b2545967205ce44be211592aafa34d6c"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn",
+]
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "minimum_redundancy"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ed9f799347e3fc3b0cc999332dbba53499551bbcf1070fcc12737645ac05b"
+dependencies = [
+ "binout",
+ "co_sort",
+ "dyn_size_of",
+ "fsum",
 ]
 
 [[package]]
@@ -786,17 +926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
-dependencies = [
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -836,24 +965,24 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -878,65 +1007,66 @@ checksum = "54b4ed3a7192fa19f5f48f99871f2755047fabefd7f222f12a1df1773796a102"
 
 [[package]]
 name = "oxjsonld"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b44046d987eafa6762dffa7f51cb7ac4fbff371fcc0e8e57060b5c478871c0"
+checksum = "2d6e5adf22439ff21ba9f9b5a3dfb456f6558b7779a8a30ec2bee7177df0c1aa"
 dependencies = [
  "json-event-parser",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.16",
+ "ryu-js",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "oxrdf"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380cb0b0f0b7c38c5c9f3f5a90b5a7e8e89c751b3f087c4d16101c16a221cf16"
+checksum = "0afd5c28e4a399c57ee2bc3accd40c7b671fdc7b6537499f14e95b265af7d7e0"
 dependencies = [
  "oxilangtag",
  "oxiri",
- "rand",
- "thiserror 2.0.16",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "oxrdfio"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c493572957ed196c076ad30c778215f85d28530e56451cdb07f564dddabfcd"
+checksum = "0f196c8d9a701c442fe3700d28afce82859926f4ddcbedf30c898a045c9339bf"
 dependencies = [
  "oxjsonld",
  "oxrdf",
  "oxrdfxml",
  "oxttl",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "oxrdfxml"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb40d6d81141e19b4898c8930e6b50c85b7155a2377b9ac1e62a9588f32b5f"
+checksum = "cd5516ae083d09bc57ec65ed5ee97701481725de6ffaa83d968ab42a96157ba1"
 dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
  "quick-xml",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "oxttl"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357f8c6b875ee108f3aa34249383c50bfda2c195a9d5e6178ba5ee53546e7225"
+checksum = "f03fd471bd54c23d76631c0a2677aa4bb308d905f6e491ee35dcb0732b7c5c6c"
 dependencies = [
  "memchr",
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -949,8 +1079,14 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.0",
+ "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peg"
@@ -963,15 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -1003,15 +1133,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -1037,7 +1167,7 @@ dependencies = [
  "spin",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1050,10 +1180,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.101"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1126,11 +1266,29 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "qwt"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1518389953b62e3b4bac17d8edc67e8291ec040523ab682479d8c706efc0b7b"
+dependencies = [
+ "bincode",
+ "clap",
+ "generic-tests",
+ "mem_dbg",
+ "minimum_redundancy",
+ "num-traits",
+ "paste",
+ "rand 0.8.6",
+ "serde",
+ "serde-big-array",
 ]
 
 [[package]]
@@ -1140,13 +1298,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1156,23 +1341,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1211,14 +1405,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1228,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1239,15 +1433,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"
@@ -1255,7 +1449,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1264,15 +1458,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
- "windows-sys 0.61.0",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1282,10 +1476,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
+name = "ryu-js"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "same-file"
@@ -1303,35 +1497,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.45",
  "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1339,12 +1559,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "slab"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1363,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -1374,20 +1588,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "sucds"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd324eaa05be64f105ea5269bb8aabd70e5dd57fa5c673b167f451b07d6c0dcd"
-dependencies = [
- "anyhow",
- "num-traits",
-]
-
-[[package]]
 name = "symbolic-common"
-version = "12.16.2"
+version = "12.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da12f8fecbbeaa1ee62c1d50dc656407e007c3ee7b2a41afce4b5089eaef15e"
+checksum = "b1f3cdeaae6779ecba2567f20bf7716718b8c4ce6717c9def4ced18786bb11ea"
 dependencies = [
  "debugid",
  "memmap2",
@@ -1397,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.16.2"
+version = "12.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd35afe0ef9d35d3dcd41c67ddf882fc832a387221338153b7cd685a105495c"
+checksum = "672c6ad9cb8fce6a1283cc9df9070073cccad00ae241b80e3686328a64e3523b"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -1408,26 +1612,26 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.45",
  "unicode-ident",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.2",
- "windows-sys 0.61.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1441,11 +1645,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1455,18 +1659,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.45",
  "syn",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.45",
  "syn",
 ]
 
@@ -1482,23 +1686,24 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
- "backtrace",
- "io-uring",
- "libc",
- "mio",
  "pin-project-lite",
- "slab",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -1508,9 +1713,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1539,28 +1744,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.5+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wasip2",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1570,56 +1775,76 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote 1.0.40",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
- "quote 1.0.40",
+ "quote 1.0.45",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.45",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.78"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1659,7 +1884,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1670,15 +1895,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1686,25 +1905,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
-dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -1713,31 +1923,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1747,22 +1940,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1771,22 +1952,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1795,22 +1964,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1819,45 +1976,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.45.1"
+name = "wit-bindgen-core"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.45",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,8 +667,7 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 [[package]]
 name = "hdt"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2b1ea7cbd25071f796251a1081ded2a164dd24e034d5f75342da35c157cf4e"
+source = "git+https://github.com/DeciSym/hdt?branch=additional-nt-perf#d37a4ec0d86d070fb1865857e585fc723b8a1715"
 dependencies = [
  "bitset-core",
  "bytesize",
@@ -679,7 +678,6 @@ dependencies = [
  "getrandom 0.3.4",
  "lasso",
  "log",
- "mem_dbg",
  "mownstr",
  "ntriple",
  "oxttl",
@@ -1387,8 +1385,7 @@ dependencies = [
 [[package]]
 name = "qwt"
 version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1518389953b62e3b4bac17d8edc67e8291ec040523ab682479d8c706efc0b7b"
+source = "git+https://github.com/rossanoventurini/qwt#310bd8170ef9a6ace90c71224b7afed01ed0372e"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +334,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "criterion"
@@ -520,6 +538,16 @@ dependencies = [
  "lazy_static",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -900,6 +928,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1462,10 +1497,12 @@ dependencies = [
 name = "rdf2hdt"
 version = "0.4.0"
 dependencies = [
+ "bzip2",
  "clap",
  "clap-verbosity-flag",
  "criterion",
  "env_logger",
+ "flate2",
  "hdt",
  "log",
  "oxrdf",
@@ -1636,6 +1673,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "rdf2hdt"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn",
+]
+
+[[package]]
 name = "dyn_size_of"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +529,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fsum"
@@ -727,10 +747,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -855,6 +978,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1098,6 +1227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1396,6 +1540,7 @@ dependencies = [
  "oxrdfio",
  "pprof",
  "tempfile",
+ "url",
  "walkdir",
 ]
 
@@ -1622,6 +1767,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1831,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1870,24 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2070,6 +2254,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2296,60 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -117,9 +118,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -159,9 +160,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitset-core"
@@ -171,15 +172,15 @@ checksum = "f421f1bcb30aa9d851a03c2920ab5d96ca920d5786645a597b5fc37922f8b89e"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytesize"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
 
 [[package]]
 name = "bzip2"
@@ -198,9 +199,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -279,7 +280,7 @@ checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
@@ -313,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "cpp_demangle"
-version = "0.5.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
@@ -331,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -412,20 +413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,13 +422,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "defmt"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote 1.0.46",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
@@ -453,15 +472,15 @@ checksum = "4a742b95783b1f45b900129082cbc47717b6a77ee8d17eea70a8ea62462f5de3"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -469,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -496,7 +515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
@@ -551,12 +570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,13 +585,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5f673e5179fc055a5cb48fb40fc3f317160598d60c93b0ef8173504117765b0"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-tests"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9ff6d6584f4f6fa911d5e07856abf1a48dc5599b3734f2eaea130f2c3baa989"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
@@ -611,15 +648,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -651,24 +686,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdt"
-version = "0.6.0"
-source = "git+https://github.com/DeciSym/hdt?branch=additional-nt-perf#d37a4ec0d86d070fb1865857e585fc723b8a1715"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7931695342dcb32a86fea5ba379939eeae25f08fc8fc5225bcc32c7b47d7ef"
 dependencies = [
+ "ahash",
  "bitset-core",
  "bytesize",
  "console_error_panic_hook",
@@ -676,7 +704,7 @@ dependencies = [
  "env_logger",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
- "lasso",
+ "hashbrown 0.14.5",
  "log",
  "mownstr",
  "ntriple",
@@ -793,12 +821,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -826,9 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -865,10 +885,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -878,22 +899,23 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -904,38 +926,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "574b0cd5e90ee2ba03a66d0611fc9a09c9a0c28b2ecc2dc8a181dd31a53ca5d7"
 
 [[package]]
-name = "lasso"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb"
-dependencies = [
- "dashmap",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libbz2-rs-sys"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -966,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "mem_dbg"
@@ -976,7 +982,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728cc9dc97593cd22f7bc81fbef70a2d391d7a9a855e7d658b653318124a6cf0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "mem_dbg-derive",
 ]
 
@@ -987,21 +993,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d84f40c93b0508d5565db79a814d02d5b2545967205ce44be211592aafa34d6c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -1092,9 +1098,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxilangtag"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f3f87617a86af77fa3691e6350483e7154c2ead9f1261b75130e21ca0f8acb"
+checksum = "5d3b4eb570abd4a1dcb062c31fd37b832264d9dc7292c3e69acfe926c87b063f"
 dependencies = [
  "serde",
 ]
@@ -1107,9 +1113,9 @@ checksum = "54b4ed3a7192fa19f5f48f99871f2755047fabefd7f222f12a1df1773796a102"
 
 [[package]]
 name = "oxjsonld"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6e5adf22439ff21ba9f9b5a3dfb456f6558b7779a8a30ec2bee7177df0c1aa"
+checksum = "f6e1380a504a8571763f13b8bcad629ff90d0300d47d8a519f3c6c599625840e"
 dependencies = [
  "json-event-parser",
  "oxiri",
@@ -1132,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "oxrdfio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f196c8d9a701c442fe3700d28afce82859926f4ddcbedf30c898a045c9339bf"
+checksum = "696223589ecbcab06b1a5df9b527dc25b0c656160cca38752fdb3878a5d3dd03"
 dependencies = [
  "oxjsonld",
  "oxrdf",
@@ -1170,19 +1176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1195,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -1289,12 +1288,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
+ "quote 1.0.46",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote 1.0.46",
  "syn",
 ]
 
@@ -1375,17 +1386,18 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "qwt"
-version = "0.3.4"
-source = "git+https://github.com/rossanoventurini/qwt#310bd8170ef9a6ace90c71224b7afed01ed0372e"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927ddd802b01109b4d7ad56dc6c8ebd2336ba1a267b0598b86af96109e4e791e"
 dependencies = [
  "bincode",
  "clap",
@@ -1492,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "rdf2hdt"
-version = "0.4.0"
+version = "0.3.0"
 dependencies = [
  "bzip2",
  "clap",
@@ -1511,19 +1523,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1544,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-demangle"
@@ -1560,7 +1563,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1573,7 +1576,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -1606,12 +1609,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1648,15 +1645,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1667,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -1678,10 +1675,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
+name = "slab"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spin"
@@ -1706,9 +1709,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "symbolic-common"
-version = "12.18.1"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f3cdeaae6779ecba2567f20bf7716718b8c4ce6717c9def4ced18786bb11ea"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
 dependencies = [
  "debugid",
  "memmap2",
@@ -1718,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.18.1"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "672c6ad9cb8fce6a1283cc9df9070073cccad00ae241b80e3686328a64e3523b"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -1729,12 +1732,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "unicode-ident",
 ]
 
@@ -1745,7 +1748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
@@ -1756,7 +1759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -1787,7 +1790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
@@ -1798,7 +1801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
@@ -1829,12 +1832,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,9 +1857,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1892,27 +1889,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1923,75 +1911,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
- "quote 1.0.45",
+ "quote 1.0.46",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2130,91 +2084,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote 1.0.45",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -2224,9 +2096,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2240,36 +2112,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -2281,7 +2153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
  "synstructure",
 ]
@@ -2315,7 +2187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ name = "benchmark"
 harness = false
 
 [dependencies]
+bzip2 = "0.6"
 clap = { version = "4.5", features = ["derive","cargo"] }
 clap-verbosity-flag = "3.0"
 env_logger = "0.11"
+flate2 = "1"
 hdt = { version = "0.6", default-features = false, features = ["nt"]}
 log = "0.4"
 oxrdf = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdf2hdt"
-version = "0.4.0"
+version = "0.3.0"
 authors = ["Greg Hanson <g.isaac.hanson@gmail.com>"]
 edition = "2024"
 license = "BSD-3-Clause"
@@ -20,7 +20,7 @@ clap = { version = "4.5", features = ["derive","cargo"] }
 clap-verbosity-flag = "3.0"
 env_logger = "0.11"
 flate2 = "1"
-hdt = { git = "https://github.com/DeciSym/hdt", default-features = false, features = ["nt"], branch = "additional-nt-perf"}
+hdt = { version = "0.7.3", default-features = false, features = ["nt"]}
 log = "0.4"
 oxrdf = "0.3"
 oxrdfio = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ harness = false
 clap = { version = "4.5", features = ["derive","cargo"] }
 clap-verbosity-flag = "3.0"
 env_logger = "0.11"
-hdt = { git = "https://github.com/KonradHoeffner/hdt/", default-features = false, features = ["nt"], tag = "0.5.0" } # waiting for 0.5.0 release
+hdt = { version = "0.6", default-features = false, features = ["nt"]}
 log = "0.4"
 oxrdf = "0.3"
 oxrdfio = "0.2"
-tempfile = "3.23"
+tempfile = "3.27"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ tempfile = "3.27"
 url = "2.5"
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["async_tokio"]}
+criterion = "0.5"
 pprof = { version = "0.15", features = ["protobuf", "protobuf-codec", "criterion"] }
 walkdir = "2.5"
-
-[package.metadata.cargo-machete]
-ignored = ["iref", "langtag"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdf2hdt"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Greg Hanson <g.isaac.hanson@gmail.com>"]
 edition = "2024"
 license = "BSD-3-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4.5", features = ["derive","cargo"] }
 clap-verbosity-flag = "3.0"
 env_logger = "0.11"
 flate2 = "1"
-hdt = { version = "0.6", default-features = false, features = ["nt"]}
+hdt = { git = "https://github.com/DeciSym/hdt", default-features = false, features = ["nt"], branch = "additional-nt-perf"}
 log = "0.4"
 oxrdf = "0.3"
 oxrdfio = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4"
 oxrdf = "0.3"
 oxrdfio = "0.2"
 tempfile = "3.27"
+url = "2.5"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"]}

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Options:
 HDT files can be generated directly in Rust.
 
 ```rust
-use rdf2hdt::hdt::buld_hdt;
+use rdf2hdt::build_hdt;
 
-let result = build_hdt(
-  vec!["tests/resources/apple.ttl".to_string()],
-  "output.hdt",
+let hdt = build_hdt(
+    &["tests/resources/apple.ttl"],
+    "output.hdt",
 )?;
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ and then generates and saves the data as HDT. Implementation is based on the [HD
 and the output HDT is intended to be consumed by one of [hdt crate](https://github.com/KonradHoeffner/hdt), [hdt-cpp](https://github.com/rdfhdt/hdt-cpp),
 or [hdt-java](https://github.com/rdfhdt/hdt-java).
 
+Inputs ending in `.gz` or `.bz2` are decompressed transparently, and `.owl` files are parsed as RDF/XML.
+
 ## Installation
 
 Install `rdf2hdt` with `cargo`:
@@ -36,7 +38,7 @@ Options:
   -i, --input <INPUT>...
           Path to input RDF file(s).
 
-          Provide the path to one or more RDF files that will be parsed and converted. Support file formats: https://crates.io/crates/oxrdfio
+          Provide the path to one or more RDF files that will be parsed and converted. RDF syntaxes supported: see https://crates.io/crates/oxrdfio. `.owl` files are parsed as RDF/XML. Inputs ending in `.gz` or `.bz2` are transparently decompressed.
 
   -o, --output <OUTPUT>
           Path to output file.

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -9,16 +9,14 @@ fn generate(c: &mut Criterion) {
     // requires tests/resources/taxonomy-nodes.nq, download via 'make init'
     // ##########################
     let tmp_dir: tempfile::TempDir = tempdir().unwrap();
-    let fname = format!("{}/rdf.hdt", tmp_dir.as_ref().display());
-    let test_hdt = fname.as_str();
-    let _ = std::fs::remove_file(test_hdt);
-    let source_rdf = "tests/resources/taxonomy-nodes.nq".to_string();
+    let test_hdt = tmp_dir.path().join("rdf.hdt");
+    let source_rdf = "tests/resources/taxonomy-nodes.nq";
 
     let mut group = c.benchmark_group("create HDT from NQ file");
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(1090));
     group.bench_function("hdt create", |b| {
-        b.iter(|| build_hdt(vec![source_rdf.clone()], test_hdt).unwrap());
+        b.iter(|| build_hdt(&[source_rdf], &test_hdt).unwrap());
     });
     group.finish();
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,25 +1,107 @@
+// Copyright (c) 2025, Decisym, LLC
+// Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
+
+//! Before/after benchmark for the non-N-Triples conversion path.
+//!
+//! `from_triples (streaming)` is the current path: parse with oxrdfio and stream
+//! triples straight into the HDT dictionary. `nt_tempfile (baseline)` reproduces
+//! the previous path: parse, serialize to an intermediate N-Triples temp file,
+//! then rebuild with `hdt`'s parallel N-Triples reader. Running both in one
+//! `cargo bench` shows whether `from_triples`' single-threaded interning costs
+//! anything versus the old serialize + parallel-reparse round trip.
+//!
+//! Input defaults to `tests/resources/taxonomy-nodes.nq` (≈23.5M triples, 4.7 GB;
+//! fetch via `make init`). Point `RDF2HDT_BENCH_INPUT` at a smaller `.nq`/`.ttl`
+//! file for a quick A/B; the benchmark is skipped if the input is absent.
+
 use criterion::{Criterion, criterion_group, criterion_main};
+use oxrdf::TripleRef;
+use oxrdfio::{RdfFormat, RdfParser, RdfSerializer};
 use pprof::criterion::{Output, PProfProfiler};
 use rdf2hdt::builder::build_hdt;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::Path;
 use std::time::Duration;
 use tempfile::tempdir;
 
+const IO_BUF: usize = 1 << 20;
+
+fn format_for(source: &Path) -> RdfFormat {
+    source
+        .extension()
+        .and_then(|e| e.to_str())
+        .and_then(RdfFormat::from_extension)
+        .unwrap_or(RdfFormat::NQuads)
+}
+
+/// Baseline: the pre-change conversion path. Parse `source` with oxrdfio,
+/// serialize every triple to an intermediate N-Triples temp file, then build the
+/// HDT with `hdt`'s parallel N-Triples reader and write it out. Kept here (not in
+/// the library) purely as the "before" reference for the A/B above.
+fn build_via_nt_tempfile(source: &Path, out_hdt: &Path) {
+    let tmp = tempfile::Builder::new().suffix(".nt").tempfile().unwrap();
+    {
+        let mut writer = BufWriter::with_capacity(IO_BUF, tmp.reopen().unwrap());
+        let reader = BufReader::with_capacity(IO_BUF, std::fs::File::open(source).unwrap());
+        let base = url::Url::from_file_path(std::fs::canonicalize(source).unwrap()).unwrap();
+        let mut serializer =
+            RdfSerializer::from_format(RdfFormat::NTriples).for_writer(writer.by_ref());
+        let quads = RdfParser::from_format(format_for(source))
+            .with_base_iri(base.as_str())
+            .unwrap()
+            .for_reader(reader);
+        for q in quads {
+            let q = q.unwrap();
+            serializer
+                .serialize_triple(TripleRef {
+                    subject: q.subject.as_ref(),
+                    predicate: q.predicate.as_ref(),
+                    object: q.object.as_ref(),
+                })
+                .unwrap();
+        }
+        serializer.finish().unwrap();
+        writer.flush().unwrap();
+    }
+    let hdt = hdt::Hdt::read_nt(tmp.path()).unwrap();
+    let mut out = BufWriter::with_capacity(IO_BUF, std::fs::File::create(out_hdt).unwrap());
+    hdt.write(&mut out).unwrap();
+    out.flush().unwrap();
+}
+
 fn generate(c: &mut Criterion) {
-    // ######### NOTE ###########
-    // requires tests/resources/taxonomy-nodes.nq, download via 'make init'
-    // ##########################
-    let tmp_dir: tempfile::TempDir = tempdir().unwrap();
-    let test_hdt = tmp_dir.path().join("rdf.hdt");
-    let source_rdf = "tests/resources/taxonomy-nodes.nq";
+    let source = std::env::var("RDF2HDT_BENCH_INPUT")
+        .unwrap_or_else(|_| "tests/resources/taxonomy-nodes.nq".to_owned());
+    let source = Path::new(&source);
+    if !source.exists() {
+        eprintln!(
+            "skipping HDT benchmark: input {} not found \
+             (run `make init`, or set RDF2HDT_BENCH_INPUT to an existing .nq/.ttl file)",
+            source.display()
+        );
+        return;
+    }
 
-    let mut group = c.benchmark_group("create HDT from NQ file");
+    let tmp_dir = tempdir().unwrap();
+    let new_hdt = tmp_dir.path().join("new.hdt");
+    let old_hdt = tmp_dir.path().join("old.hdt");
+    let source_arg = [source.to_str().expect("non-UTF-8 input path")];
+
+    let mut group = c.benchmark_group("RDF to HDT");
     group.sample_size(10);
-    group.measurement_time(Duration::from_secs(1090));
-    group.bench_function("hdt create", |b| {
-        b.iter(|| build_hdt(&[source_rdf], &test_hdt).unwrap());
-    });
-    group.finish();
+    // Target only; criterion still takes the 10-sample minimum even if a single
+    // build of the full taxonomy file overruns it. Shrink the input via
+    // RDF2HDT_BENCH_INPUT for a faster run.
+    group.measurement_time(Duration::from_secs(120));
 
+    group.bench_function("from_triples (streaming)", |b| {
+        b.iter(|| build_hdt(&source_arg, &new_hdt).unwrap());
+    });
+    group.bench_function("nt_tempfile (baseline)", |b| {
+        b.iter(|| build_via_nt_tempfile(source, &old_hdt));
+    });
+
+    group.finish();
     let _ = tmp_dir.close();
 }
 

--- a/scripts/download-sample-bench.sh
+++ b/scripts/download-sample-bench.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-set +ex
+set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DEST_DIR="${SCRIPT_DIR}/../tests/resources"
+DEST_NQ="${DEST_DIR}/taxonomy-nodes.nq"
 
-if [[ -z "${CI}" ]] && [[ -f "${SCRIPT_DIR}/../tests/resources/taxonomy-nodes.nq" ]]; then
+if [[ -z "${CI:-}" ]] && [[ -f "${DEST_NQ}" ]]; then
     echo "dependencies present"
     exit 0
 fi
 
-sudo curl -L  https://download.bio2rdf.org/files/release/4/taxonomy/taxonomy-nodes.nq.gz -o $SCRIPT_DIR/../tests/resources/taxonomy-nodes.nq.gz
-sudo apt-get install gzip -y
-gzip -d $SCRIPT_DIR/../tests/resources/taxonomy-nodes.nq.gz
+mkdir -p "${DEST_DIR}"
+curl --fail --location --show-error \
+    "https://download.bio2rdf.org/files/release/4/taxonomy/taxonomy-nodes.nq.gz" \
+    -o "${DEST_NQ}.gz"
+gunzip -f "${DEST_NQ}.gz"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, Decisym, LLC
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
-use crate::rdf_reader::convert_to_nt;
+use crate::rdf_reader::{concat_nt, convert_to_nt};
 use log::{debug, error};
 use std::{
     fmt,
@@ -58,20 +58,27 @@ pub fn build_hdt<P: AsRef<Path>, Q: AsRef<Path>>(inputs: &[P], dest: Q) -> Resul
     }
 
     let timer = std::time::Instant::now();
-    let first = inputs[0].as_ref();
-    let is_nt = inputs.len() == 1
-        && first
+    let all_nt = inputs.iter().all(|p| {
+        p.as_ref()
             .extension()
             .and_then(|e| e.to_str())
-            .is_some_and(|e| e.eq_ignore_ascii_case("nt"));
+            .is_some_and(|e| e.eq_ignore_ascii_case("nt"))
+    });
 
-    let (nt_path, _tmp_guard): (PathBuf, Option<tempfile::NamedTempFile>) = if is_nt {
-        (first.to_path_buf(), None)
-    } else {
-        let tmp = tempfile::Builder::new().suffix(".nt").tempfile()?;
-        convert_to_nt(inputs, tmp.reopen()?)?;
-        (tmp.path().to_path_buf(), Some(tmp))
-    };
+    let (nt_path, _tmp_guard): (PathBuf, Option<tempfile::NamedTempFile>) =
+        match (all_nt, inputs.len()) {
+            (true, 1) => (inputs[0].as_ref().to_path_buf(), None),
+            (true, _) => {
+                let tmp = tempfile::Builder::new().suffix(".nt").tempfile()?;
+                concat_nt(inputs, tmp.reopen()?)?;
+                (tmp.path().to_path_buf(), Some(tmp))
+            }
+            _ => {
+                let tmp = tempfile::Builder::new().suffix(".nt").tempfile()?;
+                convert_to_nt(inputs, tmp.reopen()?)?;
+                (tmp.path().to_path_buf(), Some(tmp))
+            }
+        };
 
     let converted_hdt = hdt::Hdt::read_nt(&nt_path)?;
 
@@ -82,7 +89,7 @@ pub fn build_hdt<P: AsRef<Path>, Q: AsRef<Path>>(inputs: &[P], dest: Q) -> Resul
         .create(true)
         .truncate(true)
         .open(dest.as_ref())?;
-    let mut writer = BufWriter::new(out_file);
+    let mut writer = BufWriter::with_capacity(1 << 20, out_file);
     converted_hdt.write(&mut writer)?;
     writer.flush()?;
 
@@ -168,6 +175,23 @@ mod tests {
     #[test]
     fn sparql12_tests() -> Result<(), Error> {
         run_sparql_suite("sparql12")
+    }
+
+    #[test]
+    fn multi_nt_concat() -> Result<(), Error> {
+        let tmp = tempfile::tempdir()?;
+        let a = tmp.path().join("a.nt");
+        let b = tmp.path().join("b.nt");
+        // `a` intentionally omits a trailing newline to exercise the separator.
+        std::fs::write(&a, "<http://ex/a> <http://ex/p> <http://ex/o1> .")?;
+        std::fs::write(&b, "<http://ex/b> <http://ex/p> <http://ex/o2> .\n")?;
+
+        let out = tmp.path().join("merged.hdt");
+        build_hdt(&[&a, &b], &out)?;
+
+        let reader = std::io::BufReader::new(std::fs::File::open(&out)?);
+        hdt::Hdt::read(reader)?;
+        Ok(())
     }
 
     fn find_ttl_files<P: AsRef<std::path::Path>>(dir: P) -> Vec<String> {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -55,127 +55,69 @@ mod tests {
     use super::*;
     use walkdir::WalkDir;
 
-    #[test]
-    fn sparql10_tests() -> hdt::hdt::Result<()> {
-        let input_files = find_ttl_files("tests/resources/rdf-tests/sparql/sparql10");
+    fn run_sparql_suite(suite: &str) -> hdt::hdt::Result<()> {
+        let suite_dir = format!("tests/resources/rdf-tests/sparql/{suite}");
+        assert!(
+            std::path::Path::new(&suite_dir).exists(),
+            "{suite_dir} not found — run `git submodule update --init` to fetch rdf-tests"
+        );
+
+        let input_files = find_ttl_files(&suite_dir);
+        assert!(
+            !input_files.is_empty(),
+            "no .ttl files found under {suite_dir}"
+        );
+
+        let tmp = tempfile::tempdir()?;
+        let mut failures = Vec::new();
+
         for f in &input_files {
-            if f.ends_with("manifest.ttl")
-                || std::path::Path::new(f)
-                    .parent()
-                    .unwrap()
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    == "sparql10"
-            {
+            let p = std::path::Path::new(f);
+            let parent_name = p
+                .parent()
+                .and_then(|x| x.file_name())
+                .and_then(|x| x.to_str());
+            let file_name = p.file_name().and_then(|n| n.to_str());
+
+            if file_name == Some("manifest.ttl") || parent_name == Some(suite) {
                 continue;
             }
-            let hdt_file_path = format!(
-                "tests/resources/generated/nt/sparql10/{}/{}",
-                std::path::Path::new(f)
-                    .parent()
-                    .unwrap()
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap(),
-                std::path::Path::new(f)
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .replace(".ttl", ".hdt")
-            );
-            std::fs::create_dir_all(std::path::Path::new(&hdt_file_path).parent().unwrap())?;
 
-            if build_hdt(vec![f.to_string()], &hdt_file_path).is_ok() {
-                assert!(std::path::Path::new(&hdt_file_path).exists())
+            let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or("out");
+            let out = tmp
+                .path()
+                .join(format!("{}_{}.hdt", parent_name.unwrap_or("root"), stem,));
+            let out_str = out
+                .to_str()
+                .expect("tempdir path should be valid UTF-8 on test platforms");
+
+            if let Err(e) = build_hdt(vec![f.to_string()], out_str) {
+                failures.push(format!("{f}: {e}"));
             }
         }
+
+        assert!(
+            failures.is_empty(),
+            "{} conversion failure(s) in {suite}:\n{}",
+            failures.len(),
+            failures.join("\n")
+        );
         Ok(())
+    }
+
+    #[test]
+    fn sparql10_tests() -> hdt::hdt::Result<()> {
+        run_sparql_suite("sparql10")
     }
 
     #[test]
     fn sparql11_tests() -> hdt::hdt::Result<()> {
-        let input_files = find_ttl_files("tests/resources/rdf-tests/sparql/sparql11");
-        for f in &input_files {
-            if f.ends_with("manifest.ttl")
-                || std::path::Path::new(f)
-                    .parent()
-                    .unwrap()
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    == "sparql11"
-            {
-                continue;
-            }
-            let hdt_file_path = format!(
-                "tests/resources/generated/nt/sparql11/{}/{}",
-                std::path::Path::new(f)
-                    .parent()
-                    .unwrap()
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap(),
-                std::path::Path::new(f)
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .replace(".ttl", ".hdt")
-            );
-            std::fs::create_dir_all(std::path::Path::new(&hdt_file_path).parent().unwrap())?;
-
-            if build_hdt(vec![f.to_string()], &hdt_file_path).is_ok() {
-                assert!(std::path::Path::new(&hdt_file_path).exists())
-            }
-        }
-        Ok(())
+        run_sparql_suite("sparql11")
     }
 
     #[test]
     fn sparql12_tests() -> hdt::hdt::Result<()> {
-        let input_files = find_ttl_files("tests/resources/rdf-tests/sparql/sparql12");
-        for f in &input_files {
-            if f.ends_with("manifest.ttl")
-                || std::path::Path::new(f)
-                    .parent()
-                    .unwrap()
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    == "sparql12"
-            {
-                continue;
-            }
-            let hdt_file_path = format!(
-                "tests/resources/generated/nt/sparql12/{}/{}",
-                std::path::Path::new(f)
-                    .parent()
-                    .unwrap()
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap(),
-                std::path::Path::new(f)
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .replace(".ttl", ".hdt")
-            );
-            std::fs::create_dir_all(std::path::Path::new(&hdt_file_path).parent().unwrap())?;
-
-            if build_hdt(vec![f.to_string()], &hdt_file_path).is_ok() {
-                assert!(std::path::Path::new(&hdt_file_path).exists())
-            }
-        }
-        Ok(())
+        run_sparql_suite("sparql12")
     }
 
     fn find_ttl_files<P: AsRef<std::path::Path>>(dir: P) -> Vec<String> {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,34 +5,34 @@ use crate::rdf_reader::convert_to_nt;
 use log::{debug, error};
 use std::{
     fs::OpenOptions,
-    io::{BufWriter, Write},
+    io::{self, BufWriter, Write},
+    path::{Path, PathBuf},
 };
 
 pub fn build_hdt(file_paths: Vec<String>, dest_file: &str) -> Result<hdt::Hdt, hdt::hdt::Error> {
     if file_paths.is_empty() {
         error!("no files provided");
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "no files provided to convert",
-        )
-        .into());
+        return Err(
+            io::Error::new(io::ErrorKind::InvalidData, "no files provided to convert").into(),
+        );
     }
 
     let timer = std::time::Instant::now();
-    let mut used_tmp = false;
-    let nt_file = if file_paths.len() == 1 && file_paths[0].ends_with(".nt") {
-        file_paths[0].clone()
+    let is_nt = file_paths.len() == 1
+        && Path::new(&file_paths[0])
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("nt"));
+
+    let (nt_path, _tmp_guard): (PathBuf, Option<tempfile::NamedTempFile>) = if is_nt {
+        (PathBuf::from(&file_paths[0]), None)
     } else {
-        used_tmp = true;
-        let tmp_file = tempfile::Builder::new()
-            .disable_cleanup(true)
-            .suffix(".nt")
-            .tempfile()?;
-        convert_to_nt(file_paths, tmp_file.reopen()?).expect("failed to convert file to NT");
-        tmp_file.path().to_str().unwrap().to_string()
+        let tmp = tempfile::Builder::new().suffix(".nt").tempfile()?;
+        convert_to_nt(file_paths, tmp.reopen()?).map_err(|e| io::Error::other(e.to_string()))?;
+        (tmp.path().to_path_buf(), Some(tmp))
     };
 
-    let converted_hdt = hdt::Hdt::read_nt(std::path::Path::new(&nt_file))?;
+    let converted_hdt = hdt::Hdt::read_nt(&nt_path)?;
 
     debug!("HDT build time: {:?}", timer.elapsed());
 
@@ -44,9 +44,6 @@ pub fn build_hdt(file_paths: Vec<String>, dest_file: &str) -> Result<hdt::Hdt, h
     let mut writer = BufWriter::new(out_file);
     converted_hdt.write(&mut writer)?;
     writer.flush()?;
-    if used_tmp {
-        let _ = std::fs::remove_file(nt_file);
-    }
 
     debug!("Total execution time: {:?}", timer.elapsed());
     Ok(converted_hdt)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, Decisym, LLC
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
-use crate::rdf_reader::{concat_nt, convert_to_nt};
+use crate::rdf_reader::{concat_nt, convert_to_hdt};
 use log::{debug, error};
 use std::{
     fmt,
@@ -65,22 +65,24 @@ pub fn build_hdt<P: AsRef<Path>, Q: AsRef<Path>>(inputs: &[P], dest: Q) -> Resul
             .is_some_and(|e| e.eq_ignore_ascii_case("nt"))
     });
 
-    let (nt_path, _tmp_guard): (PathBuf, Option<tempfile::NamedTempFile>) =
-        match (all_nt, inputs.len()) {
-            (true, 1) => (inputs[0].as_ref().to_path_buf(), None),
-            (true, _) => {
-                let tmp = tempfile::Builder::new().suffix(".nt").tempfile()?;
-                concat_nt(inputs, tmp.reopen()?)?;
-                (tmp.path().to_path_buf(), Some(tmp))
-            }
-            _ => {
-                let tmp = tempfile::Builder::new().suffix(".nt").tempfile()?;
-                convert_to_nt(inputs, tmp.reopen()?)?;
-                (tmp.path().to_path_buf(), Some(tmp))
-            }
+    // N-Triples inputs go straight into `hdt`'s parallel N-Triples reader: a
+    // single file as-is, multiple files concatenated into one temp file. Any
+    // other RDF syntax is parsed with oxrdfio and streamed directly into the HDT
+    // dictionary via `Hdt::from_triples`, skipping a serialize-to-NT-and-reparse
+    // round trip through a temp file.
+    let converted_hdt = if all_nt {
+        let (nt_path, _tmp_guard): (PathBuf, Option<tempfile::NamedTempFile>) = if inputs.len() == 1
+        {
+            (inputs[0].as_ref().to_path_buf(), None)
+        } else {
+            let tmp = tempfile::Builder::new().suffix(".nt").tempfile()?;
+            concat_nt(inputs, tmp.reopen()?)?;
+            (tmp.path().to_path_buf(), Some(tmp))
         };
-
-    let converted_hdt = hdt::Hdt::read_nt(&nt_path)?;
+        hdt::Hdt::read_nt(&nt_path)?
+    } else {
+        convert_to_hdt(inputs)?
+    };
 
     debug!("HDT build time: {:?}", timer.elapsed());
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,31 +4,72 @@
 use crate::rdf_reader::convert_to_nt;
 use log::{debug, error};
 use std::{
+    fmt,
     fs::OpenOptions,
     io::{self, BufWriter, Write},
     path::{Path, PathBuf},
 };
 
-pub fn build_hdt(file_paths: Vec<String>, dest_file: &str) -> Result<hdt::Hdt, hdt::hdt::Error> {
-    if file_paths.is_empty() {
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    Hdt(hdt::hdt::Error),
+    Parse(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Io(e) => write!(f, "I/O error: {e}"),
+            Error::Hdt(e) => write!(f, "HDT error: {e}"),
+            Error::Parse(e) => write!(f, "parse error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(e) => Some(e),
+            Error::Hdt(e) => Some(e),
+            Error::Parse(e) => Some(e.as_ref()),
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl From<hdt::hdt::Error> for Error {
+    fn from(e: hdt::hdt::Error) -> Self {
+        Error::Hdt(e)
+    }
+}
+
+pub fn build_hdt<P: AsRef<Path>, Q: AsRef<Path>>(inputs: &[P], dest: Q) -> Result<hdt::Hdt, Error> {
+    if inputs.is_empty() {
         error!("no files provided");
         return Err(
-            io::Error::new(io::ErrorKind::InvalidData, "no files provided to convert").into(),
+            io::Error::new(io::ErrorKind::InvalidInput, "no files provided to convert").into(),
         );
     }
 
     let timer = std::time::Instant::now();
-    let is_nt = file_paths.len() == 1
-        && Path::new(&file_paths[0])
+    let first = inputs[0].as_ref();
+    let is_nt = inputs.len() == 1
+        && first
             .extension()
             .and_then(|e| e.to_str())
             .is_some_and(|e| e.eq_ignore_ascii_case("nt"));
 
     let (nt_path, _tmp_guard): (PathBuf, Option<tempfile::NamedTempFile>) = if is_nt {
-        (PathBuf::from(&file_paths[0]), None)
+        (first.to_path_buf(), None)
     } else {
         let tmp = tempfile::Builder::new().suffix(".nt").tempfile()?;
-        convert_to_nt(file_paths, tmp.reopen()?).map_err(|e| io::Error::other(e.to_string()))?;
+        convert_to_nt(inputs, tmp.reopen()?)?;
         (tmp.path().to_path_buf(), Some(tmp))
     };
 
@@ -40,7 +81,7 @@ pub fn build_hdt(file_paths: Vec<String>, dest_file: &str) -> Result<hdt::Hdt, h
         .write(true)
         .create(true)
         .truncate(true)
-        .open(dest_file)?;
+        .open(dest.as_ref())?;
     let mut writer = BufWriter::new(out_file);
     converted_hdt.write(&mut writer)?;
     writer.flush()?;
@@ -55,7 +96,7 @@ mod tests {
     use super::*;
     use walkdir::WalkDir;
 
-    fn run_sparql_suite(suite: &str) -> hdt::hdt::Result<()> {
+    fn run_sparql_suite(suite: &str) -> Result<(), Error> {
         let suite_dir = format!("tests/resources/rdf-tests/sparql/{suite}");
         assert!(
             std::path::Path::new(&suite_dir).exists(),
@@ -86,12 +127,9 @@ mod tests {
             let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or("out");
             let out = tmp
                 .path()
-                .join(format!("{}_{}.hdt", parent_name.unwrap_or("root"), stem,));
-            let out_str = out
-                .to_str()
-                .expect("tempdir path should be valid UTF-8 on test platforms");
+                .join(format!("{}_{}.hdt", parent_name.unwrap_or("root"), stem));
 
-            if let Err(e) = build_hdt(vec![f.to_string()], out_str) {
+            if let Err(e) = build_hdt(std::slice::from_ref(f), &out) {
                 failures.push(format!("{f}: {e}"));
             }
         }
@@ -106,17 +144,17 @@ mod tests {
     }
 
     #[test]
-    fn sparql10_tests() -> hdt::hdt::Result<()> {
+    fn sparql10_tests() -> Result<(), Error> {
         run_sparql_suite("sparql10")
     }
 
     #[test]
-    fn sparql11_tests() -> hdt::hdt::Result<()> {
+    fn sparql11_tests() -> Result<(), Error> {
         run_sparql_suite("sparql11")
     }
 
     #[test]
-    fn sparql12_tests() -> hdt::hdt::Result<()> {
+    fn sparql12_tests() -> Result<(), Error> {
         run_sparql_suite("sparql12")
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -130,7 +130,19 @@ mod tests {
                 .join(format!("{}_{}.hdt", parent_name.unwrap_or("root"), stem));
 
             if let Err(e) = build_hdt(std::slice::from_ref(f), &out) {
-                failures.push(format!("{f}: {e}"));
+                failures.push(format!("{f}: build: {e}"));
+                continue;
+            }
+
+            let reader = match std::fs::File::open(&out) {
+                Ok(file) => std::io::BufReader::new(file),
+                Err(e) => {
+                    failures.push(format!("{f}: open: {e}"));
+                    continue;
+                }
+            };
+            if let Err(e) = hdt::Hdt::read(reader) {
+                failures.push(format!("{f}: read: {e}"));
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,5 @@
 
 pub mod builder;
 pub(crate) mod rdf_reader;
+
+pub use builder::{Error, build_hdt};

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn main() -> ExitCode {
         .init();
 
     match &cli.command {
-        Some(Commands::Convert { input, output }) => match build_hdt(input.clone(), output) {
+        Some(Commands::Convert { input, output }) => match build_hdt(input, output) {
             Ok(_) => ExitCode::SUCCESS,
             Err(e) => {
                 eprintln!("Error: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@
 //! ## Features
 //! - Parses RDF input and converts it to RDF triples
 //! - Convert NTriple data into HDT format
+//! - Transparent gzip (`.gz`) and bzip2 (`.bz2`) decompression of input files
+//! - `.owl` files parsed as RDF/XML
 //!
 //! ## Usage
 //! Run the rdf2hdt converter from the command line. For detailed usage information, run:
@@ -56,7 +58,9 @@ enum Commands {
         /// Path to input RDF file(s).
         ///
         /// Provide the path to one or more RDF files that will be parsed and converted.
-        /// Support file formats: https://crates.io/crates/oxrdfio
+        /// RDF syntaxes supported: see https://crates.io/crates/oxrdfio.
+        /// `.owl` files are parsed as RDF/XML. Inputs ending in `.gz` or `.bz2`
+        /// are transparently decompressed.
         #[arg(short, long, num_args = 1..)]
         input: Vec<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,9 @@
 //! ```
 //! This will take `data.ttl`, convert to NTriple, and generate and save the HDT output to `result.hdt`.
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use rdf2hdt::builder::build_hdt;
+use std::process::ExitCode;
 
 /// Command-line interface for rdf2hdt Converter
 ///
@@ -67,7 +68,7 @@ enum Commands {
     },
 }
 
-fn main() {
+fn main() -> ExitCode {
     let cli = Cli::parse();
 
     env_logger::Builder::new()
@@ -76,9 +77,16 @@ fn main() {
 
     match &cli.command {
         Some(Commands::Convert { input, output }) => match build_hdt(input.clone(), output) {
-            Ok(_) => {}
-            Err(e) => eprintln!("Error writing: {}", e),
+            Ok(_) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("Error: {e}");
+                ExitCode::FAILURE
+            }
         },
-        None => {}
+        None => {
+            let _ = Cli::command().print_help();
+            eprintln!();
+            ExitCode::FAILURE
+        }
     }
 }

--- a/src/rdf_reader.rs
+++ b/src/rdf_reader.rs
@@ -2,20 +2,68 @@
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
 use crate::builder::Error;
+use bzip2::bufread::MultiBzDecoder;
+use flate2::bufread::MultiGzDecoder;
 use log::{debug, error, warn};
 use oxrdfio::RdfSerializer;
 use oxrdfio::{
     RdfFormat::{self, NTriples},
     RdfParseError, RdfParser,
 };
+use std::fs::File;
 use std::io::Write;
 use std::{
-    io::{self, BufReader, BufWriter},
-    path::Path,
+    io::{self, BufReader, BufWriter, Read},
+    path::{Path, PathBuf},
 };
 use url::Url;
 
 const IO_BUF: usize = 1 << 20;
+
+fn open_rdf_reader(file: &Path) -> io::Result<Box<dyn Read>> {
+    let fp = File::open(file)?;
+    let buffered = BufReader::with_capacity(IO_BUF, fp);
+    match file.extension().and_then(|e| e.to_str()) {
+        Some(e) if e.eq_ignore_ascii_case("gz") => Ok(Box::new(BufReader::with_capacity(
+            IO_BUF,
+            MultiGzDecoder::new(buffered),
+        ))),
+        Some(e) if e.eq_ignore_ascii_case("bz2") => Ok(Box::new(BufReader::with_capacity(
+            IO_BUF,
+            MultiBzDecoder::new(buffered),
+        ))),
+        _ => Ok(Box::new(buffered)),
+    }
+}
+
+fn rdf_format_from_path(file: &Path) -> io::Result<RdfFormat> {
+    let format_path: PathBuf = match file.extension().and_then(|e| e.to_str()) {
+        Some(e) if e.eq_ignore_ascii_case("gz") || e.eq_ignore_ascii_case("bz2") => {
+            file.with_extension("")
+        }
+        _ => file.to_path_buf(),
+    };
+
+    let ext = format_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("file {} has no usable extension", file.display()),
+            )
+        })?;
+    if ext.eq_ignore_ascii_case("owl") {
+        return Ok(RdfFormat::RdfXml);
+    }
+    RdfFormat::from_extension(ext).ok_or_else(|| {
+        error!("unrecognized file extension for {}", file.display());
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unrecognized file extension for {}", file.display()),
+        )
+    })
+}
 
 pub(crate) fn convert_to_nt<P: AsRef<Path>>(
     file_paths: &[P],
@@ -24,29 +72,16 @@ pub(crate) fn convert_to_nt<P: AsRef<Path>>(
     let mut dest_writer = BufWriter::with_capacity(IO_BUF, output_file);
     for file in file_paths {
         let file = file.as_ref();
-        let source = std::fs::File::open(file).map_err(|e| {
+        let source_reader = open_rdf_reader(file).map_err(|e| {
             error!("Error opening file {}: {e:?}", file.display());
             e
         })?;
-        let source_reader = BufReader::with_capacity(IO_BUF, source);
 
         debug!("converting {} to nt format", file.display());
 
         let mut serializer = RdfSerializer::from_format(NTriples).for_writer(dest_writer.by_ref());
         let v = std::time::Instant::now();
-        let ext = file.extension().and_then(|e| e.to_str()).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("file {} has no usable extension", file.display()),
-            )
-        })?;
-        let rdf_format = RdfFormat::from_extension(ext).ok_or_else(|| {
-            error!("unrecognized file extension for {}", file.display());
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("unrecognized file extension for {}", file.display()),
-            )
-        })?;
+        let rdf_format = rdf_format_from_path(file)?;
         let abs_path = std::fs::canonicalize(file)?;
         let base_iri = Url::from_file_path(&abs_path).map_err(|_| {
             io::Error::new(
@@ -132,5 +167,66 @@ mod tests {
 
         assert!(quads.is_ok());
         assert_eq!(quads.unwrap().len(), 9)
+    }
+
+    fn count_triples_in(nt_file: &tempfile::NamedTempFile) -> usize {
+        let reader = BufReader::new(nt_file.reopen().expect("error opening tmp file"));
+        RdfParser::from_format(NTriples)
+            .for_reader(reader)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("parse nt")
+            .len()
+    }
+
+    #[test]
+    fn gzipped_ttl_input() -> Result<(), Error> {
+        let tmp = tempfile::tempdir()?;
+        let gz_path = tmp.path().join("apple.ttl.gz");
+        let source = std::fs::read("tests/resources/apple.ttl")?;
+        let mut enc =
+            flate2::write::GzEncoder::new(File::create(&gz_path)?, flate2::Compression::default());
+        enc.write_all(&source)?;
+        enc.finish()?;
+
+        let out = tempfile::Builder::new().suffix(".nt").tempfile()?;
+        convert_to_nt(&[&gz_path], out.reopen()?)?;
+        assert_eq!(count_triples_in(&out), 9);
+        Ok(())
+    }
+
+    #[test]
+    fn bzipped_ttl_input() -> Result<(), Error> {
+        let tmp = tempfile::tempdir()?;
+        let bz_path = tmp.path().join("apple.ttl.bz2");
+        let source = std::fs::read("tests/resources/apple.ttl")?;
+        let mut enc =
+            bzip2::write::BzEncoder::new(File::create(&bz_path)?, bzip2::Compression::default());
+        enc.write_all(&source)?;
+        enc.finish()?;
+
+        let out = tempfile::Builder::new().suffix(".nt").tempfile()?;
+        convert_to_nt(&[&bz_path], out.reopen()?)?;
+        assert_eq!(count_triples_in(&out), 9);
+        Ok(())
+    }
+
+    #[test]
+    fn owl_as_rdfxml() -> Result<(), Error> {
+        let tmp = tempfile::tempdir()?;
+        let owl_path = tmp.path().join("tiny.owl");
+        std::fs::write(
+            &owl_path,
+            r#"<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="http://example.org/a">
+    <rdf:type rdf:resource="http://example.org/Thing"/>
+  </rdf:Description>
+</rdf:RDF>"#,
+        )?;
+
+        let out = tempfile::Builder::new().suffix(".nt").tempfile()?;
+        convert_to_nt(&[&owl_path], out.reopen()?)?;
+        assert_eq!(count_triples_in(&out), 1);
+        Ok(())
     }
 }

--- a/src/rdf_reader.rs
+++ b/src/rdf_reader.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025, Decisym, LLC
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
+use crate::builder::Error;
 use log::{debug, error, warn};
 use oxrdfio::RdfSerializer;
 use oxrdfio::{
@@ -9,78 +10,73 @@ use oxrdfio::{
 };
 use std::io::Write;
 use std::{
-    error::Error,
-    io::{BufReader, BufWriter},
+    io::{self, BufReader, BufWriter},
     path::Path,
 };
 use url::Url;
 
-pub(crate) fn convert_to_nt(
-    file_paths: Vec<String>,
+pub(crate) fn convert_to_nt<P: AsRef<Path>>(
+    file_paths: &[P],
     output_file: std::fs::File,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), Error> {
     let mut dest_writer = BufWriter::new(output_file);
     for file in file_paths {
-        let source = match std::fs::File::open(&file) {
-            Ok(f) => f,
-            Err(e) => {
-                error!("Error opening file {file:?}: {e:?}");
-                return Err(e.into());
-            }
-        };
+        let file = file.as_ref();
+        let source = std::fs::File::open(file).map_err(|e| {
+            error!("Error opening file {}: {e:?}", file.display());
+            e
+        })?;
         let source_reader = BufReader::new(source);
 
-        debug!("converting {} to nt format", &file);
+        debug!("converting {} to nt format", file.display());
 
         let mut serializer = RdfSerializer::from_format(NTriples).for_writer(dest_writer.by_ref());
         let v = std::time::Instant::now();
-        let ext = Path::new(&file)
-            .extension()
-            .and_then(|e| e.to_str())
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    format!("file {file} has no usable extension"),
-                )
-            })?;
-        let rdf_format = RdfFormat::from_extension(ext).ok_or_else(|| {
-            error!("unrecognized file extension for {file}");
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("unrecognized file extension for {file}"),
+        let ext = file.extension().and_then(|e| e.to_str()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("file {} has no usable extension", file.display()),
             )
         })?;
-        let abs_path = std::fs::canonicalize(&file)?;
+        let rdf_format = RdfFormat::from_extension(ext).ok_or_else(|| {
+            error!("unrecognized file extension for {}", file.display());
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unrecognized file extension for {}", file.display()),
+            )
+        })?;
+        let abs_path = std::fs::canonicalize(file)?;
         let base_iri = Url::from_file_path(&abs_path).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("cannot build file:// URI for {file}"),
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("cannot build file:// URI for {}", file.display()),
             )
         })?;
         let quads = RdfParser::from_format(rdf_format)
-            .with_base_iri(base_iri.as_str())?
+            .with_base_iri(base_iri.as_str())
+            .map_err(|e| Error::Parse(Box::new(e)))?
             .for_reader(source_reader);
         let mut warned = false;
         for q in quads {
             let q = match q {
                 Ok(v) => v,
-                Err(e) => {
-                    match e {
-                        RdfParseError::Io(v) => {
-                            // I/O error while reading file
-                            error!("Error reading file {file}: {v}");
-                            return Err(v.into());
-                        }
-                        RdfParseError::Syntax(syn_err) => {
-                            error!("syntax error for RDF file {file}: {syn_err}");
-                            return Err(syn_err.into());
-                        }
+                Err(e) => match e {
+                    RdfParseError::Io(v) => {
+                        error!("Error reading file {}: {v}", file.display());
+                        return Err(v.into());
                     }
-                }
+                    RdfParseError::Syntax(syn_err) => {
+                        error!("syntax error for RDF file {}: {syn_err}", file.display());
+                        return Err(Error::Parse(Box::new(syn_err)));
+                    }
+                },
             };
             if !warned && q.graph_name != oxrdf::GraphName::DefaultGraph {
                 warned = true;
-                warn!("HDT does not support named graphs, merging triples for {file}");
+                warn!(
+                    "HDT does not support named graphs, merging triples for {}",
+                    file.display()
+                );
             }
             serializer.serialize_triple(oxrdf::TripleRef {
                 subject: q.subject.as_ref(),
@@ -106,7 +102,7 @@ mod tests {
         let tmp_file = tempfile::Builder::new().suffix(".nt").tempfile().expect("");
         assert!(
             (convert_to_nt(
-                vec!["tests/resources/apple.ttl".to_string()],
+                &["tests/resources/apple.ttl"],
                 tmp_file.reopen().expect("error opening tmp file")
             ))
             .is_ok()

--- a/src/rdf_reader.rs
+++ b/src/rdf_reader.rs
@@ -33,23 +33,33 @@ pub(crate) fn convert_to_nt(
 
         let mut serializer = RdfSerializer::from_format(NTriples).for_writer(dest_writer.by_ref());
         let v = std::time::Instant::now();
-        let rdf_format = if let Some(t) =
-            RdfFormat::from_extension(Path::new(&file).extension().unwrap().to_str().unwrap())
-        {
-            t
-        } else {
+        let ext = Path::new(&file)
+            .extension()
+            .and_then(|e| e.to_str())
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("file {file} has no usable extension"),
+                )
+            })?;
+        let rdf_format = RdfFormat::from_extension(ext).ok_or_else(|| {
             error!("unrecognized file extension for {file}");
-            return Err(std::io::Error::new(
+            std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("unrecognized file extension for {file}"),
             )
-            .into());
-        };
+        })?;
+        let file_name = Path::new(&file)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("file {file} has no usable file name"),
+                )
+            })?;
         let quads = RdfParser::from_format(rdf_format)
-            .with_base_iri(format!(
-                "file://{}",
-                Path::new(&file).file_name().unwrap().to_str().unwrap()
-            ))?
+            .with_base_iri(format!("file://{file_name}"))?
             .for_reader(source_reader);
         let mut warned = false;
         for q in quads {

--- a/src/rdf_reader.rs
+++ b/src/rdf_reader.rs
@@ -13,6 +13,7 @@ use std::{
     io::{BufReader, BufWriter},
     path::Path,
 };
+use url::Url;
 
 pub(crate) fn convert_to_nt(
     file_paths: Vec<String>,
@@ -49,17 +50,15 @@ pub(crate) fn convert_to_nt(
                 format!("unrecognized file extension for {file}"),
             )
         })?;
-        let file_name = Path::new(&file)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    format!("file {file} has no usable file name"),
-                )
-            })?;
+        let abs_path = std::fs::canonicalize(&file)?;
+        let base_iri = Url::from_file_path(&abs_path).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("cannot build file:// URI for {file}"),
+            )
+        })?;
         let quads = RdfParser::from_format(rdf_format)
-            .with_base_iri(format!("file://{file_name}"))?
+            .with_base_iri(base_iri.as_str())?
             .for_reader(source_reader);
         let mut warned = false;
         for q in quads {

--- a/src/rdf_reader.rs
+++ b/src/rdf_reader.rs
@@ -5,15 +5,11 @@ use crate::builder::Error;
 use bzip2::bufread::MultiBzDecoder;
 use flate2::bufread::MultiGzDecoder;
 use log::{debug, error, warn};
-use oxrdfio::RdfSerializer;
-use oxrdfio::{
-    RdfFormat::{self, NTriples},
-    RdfParseError, RdfParser,
-};
+use oxrdfio::{RdfFormat, RdfParseError, RdfParser, ReaderQuadParser};
 use std::fs::File;
 use std::io::Write;
 use std::{
-    io::{self, BufReader, BufWriter, Read},
+    io::{self, BufReader, Read},
     path::{Path, PathBuf},
 };
 use url::Url;
@@ -65,68 +61,144 @@ fn rdf_format_from_path(file: &Path) -> io::Result<RdfFormat> {
     })
 }
 
-pub(crate) fn convert_to_nt<P: AsRef<Path>>(
-    file_paths: &[P],
-    output_file: std::fs::File,
-) -> Result<(), Error> {
-    let mut dest_writer = BufWriter::with_capacity(IO_BUF, output_file);
-    for file in file_paths {
-        let file = file.as_ref();
-        let source_reader = open_rdf_reader(file).map_err(|e| {
-            error!("Error opening file {}: {e:?}", file.display());
-            e
-        })?;
-
-        debug!("converting {} to nt format", file.display());
-
-        let mut serializer = RdfSerializer::from_format(NTriples).for_writer(dest_writer.by_ref());
-        let v = std::time::Instant::now();
-        let rdf_format = rdf_format_from_path(file)?;
-        let abs_path = std::fs::canonicalize(file)?;
-        let base_iri = Url::from_file_path(&abs_path).map_err(|_| {
-            io::Error::new(
+/// Parse one or more non-N-Triples RDF files with oxrdfio and build an HDT
+/// directly from the parsed triples, streaming them into the dictionary instead
+/// of serializing to an intermediate N-Triples temp file and reparsing it.
+///
+/// The triple stream is lazy: [`hdt::Hdt::from_triples`] interns each term and
+/// drops the source `[String; 3]` before pulling the next triple, so peak memory
+/// holds the HDT dictionary/triples but not a second full copy of the terms.
+///
+/// `from_triples` takes `Item = [S; 3]`, not `Result`, so the first parse error
+/// is stashed by the adapter (which then ends the stream) and returned here once
+/// `from_triples` has unwound the iterator. This preserves oxrdfio's detailed
+/// syntax diagnostics — note `hdt`'s own N-Triples reader would instead panic on
+/// malformed input.
+pub(crate) fn convert_to_hdt<P: AsRef<Path>>(file_paths: &[P]) -> Result<hdt::Hdt, Error> {
+    // Header dataset IRI: a deterministic file:// URI from the first input
+    // (the old path labelled it with a random temp-file path).
+    let dataset_iri = match file_paths.first() {
+        Some(f) => file_base_iri(f.as_ref())?.to_string(),
+        None => {
+            return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!("cannot build file:// URI for {}", file.display()),
+                "no files provided to convert",
             )
-        })?;
-        let quads = RdfParser::from_format(rdf_format)
-            .with_base_iri(base_iri.as_str())
-            .map_err(|e| Error::Parse(Box::new(e)))?
-            .for_reader(source_reader);
-        let mut warned = false;
-        for q in quads {
-            let q = match q {
-                Ok(v) => v,
-                Err(e) => match e {
-                    RdfParseError::Io(v) => {
-                        error!("Error reading file {}: {v}", file.display());
-                        return Err(v.into());
-                    }
-                    RdfParseError::Syntax(syn_err) => {
-                        error!("syntax error for RDF file {}: {syn_err}", file.display());
-                        return Err(Error::Parse(Box::new(syn_err)));
-                    }
-                },
-            };
-            if !warned && q.graph_name != oxrdf::GraphName::DefaultGraph {
-                warned = true;
-                warn!(
-                    "HDT does not support named graphs, merging triples for {}",
-                    file.display()
-                );
-            }
-            serializer.serialize_triple(oxrdf::TripleRef {
-                subject: q.subject.as_ref(),
-                predicate: q.predicate.as_ref(),
-                object: q.object.as_ref(),
-            })?
+            .into());
         }
+    };
 
-        serializer.finish()?;
-        debug!("RDF to NTriple convert time: {:?}", v.elapsed());
+    let timer = std::time::Instant::now();
+    let mut first_err: Option<Error> = None;
+    let triples = file_paths
+        .iter()
+        .flat_map(|f| file_triples(f.as_ref()))
+        .map_while(|r| match r {
+            Ok(triple) => Some(triple),
+            Err(e) => {
+                first_err = Some(e);
+                None
+            }
+        });
+
+    let result = hdt::Hdt::from_triples(triples, &dataset_iri);
+    // `triples` — and with it the &mut borrow of `first_err` held by the adapter
+    // — is fully consumed and dropped inside `from_triples`, so the stash is
+    // readable again here. A stashed parse error takes priority over any error
+    // `from_triples` may report from the truncated stream.
+    if let Some(e) = first_err {
+        return Err(e);
     }
-    dest_writer.flush()?;
-    Ok(())
+    let hdt = result?;
+    debug!("RDF parse + HDT build time: {:?}", timer.elapsed());
+    Ok(hdt)
+}
+
+/// Lazily yield every triple in `file` as HDT dictionary strings. Per-file setup
+/// failures (open / format detection / base IRI) surface as a single terminal
+/// `Err` item, so the caller stops the whole stream on the first error just as
+/// the old sequential conversion did.
+fn file_triples(file: &Path) -> Box<dyn Iterator<Item = Result<[String; 3], Error>>> {
+    let parser = match open_parser(file) {
+        Ok(p) => p,
+        Err(e) => return Box::new(std::iter::once(Err(e))),
+    };
+    debug!("streaming {} into HDT dictionary", file.display());
+
+    let file = file.to_path_buf();
+    let mut warned = false;
+    Box::new(parser.map(move |q| {
+        let q = q.map_err(|e| parse_error(&file, e))?;
+        if !warned && q.graph_name != oxrdf::GraphName::DefaultGraph {
+            warned = true;
+            warn!(
+                "HDT does not support named graphs, merging triples for {}",
+                file.display()
+            );
+        }
+        Ok([
+            term_string(q.subject.into()),
+            q.predicate.into_string(),
+            term_string(q.object),
+        ])
+    }))
+}
+
+/// Open `file` (transparently decompressing `.gz`/`.bz2`) and configure an
+/// oxrdfio parser for its syntax, resolving relative IRIs against the file's
+/// `file://` URI.
+fn open_parser(file: &Path) -> Result<ReaderQuadParser<Box<dyn Read>>, Error> {
+    let reader = open_rdf_reader(file).map_err(|e| {
+        error!("Error opening file {}: {e:?}", file.display());
+        e
+    })?;
+    let rdf_format = rdf_format_from_path(file)?;
+    let base_iri = file_base_iri(file)?;
+    Ok(RdfParser::from_format(rdf_format)
+        .with_base_iri(base_iri.as_str())
+        .map_err(|e| Error::Parse(Box::new(e)))?
+        .for_reader(reader))
+}
+
+/// The `file://` base IRI used to resolve relative IRIs while parsing `file`.
+fn file_base_iri(file: &Path) -> Result<Url, Error> {
+    let abs_path = std::fs::canonicalize(file)?;
+    Url::from_file_path(&abs_path).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("cannot build file:// URI for {}", file.display()),
+        )
+        .into()
+    })
+}
+
+/// Translate an oxrdfio parse error for `file` into our error type, logging it
+/// the same way the previous N-Triples conversion path did.
+fn parse_error(file: &Path, e: RdfParseError) -> Error {
+    match e {
+        RdfParseError::Io(v) => {
+            error!("Error reading file {}: {v}", file.display());
+            Error::Io(v)
+        }
+        RdfParseError::Syntax(syn_err) => {
+            error!("syntax error for RDF file {}: {syn_err}", file.display());
+            Error::Parse(Box::new(syn_err))
+        }
+    }
+}
+
+/// Render an oxrdf term in the HDT dictionary string form expected by
+/// [`hdt::Hdt::from_triples`]: bare IRIs (no angle brackets), literals keeping
+/// their quotes / language tag / `^^<datatype>`, and blank nodes as `_:id`. This
+/// is exactly the form `hdt`'s N-Triples reader derives internally (and that
+/// `Hdt::triples_all` returns), so the resulting HDT is identical to the old
+/// serialize-and-reparse path.
+fn term_string(t: oxrdf::Term) -> String {
+    match t {
+        oxrdf::Term::NamedNode(n) => n.into_string(),
+        oxrdf::Term::BlankNode(b) => b.to_string(),
+        oxrdf::Term::Literal(l) => l.to_string(),
+    }
 }
 
 pub(crate) fn concat_nt<P: AsRef<Path>>(
@@ -149,33 +221,37 @@ pub(crate) fn concat_nt<P: AsRef<Path>>(
 mod tests {
 
     use super::*;
+    use std::collections::HashSet;
 
-    #[test]
-    fn test_rdf() {
-        let tmp_file = tempfile::Builder::new().suffix(".nt").tempfile().expect("");
-        assert!(
-            (convert_to_nt(
-                &["tests/resources/apple.ttl"],
-                tmp_file.reopen().expect("error opening tmp file")
-            ))
-            .is_ok()
-        );
-        let source_reader = BufReader::new(tmp_file.reopen().expect("error opening tmp file"));
-        let quads = RdfParser::from_format(NTriples)
-            .for_reader(source_reader)
-            .collect::<Result<Vec<_>, _>>();
-
-        assert!(quads.is_ok());
-        assert_eq!(quads.unwrap().len(), 9)
+    fn count_via_convert<P: AsRef<Path>>(input: P) -> usize {
+        convert_to_hdt(&[input])
+            .expect("convert")
+            .triples_all()
+            .count()
     }
 
-    fn count_triples_in(nt_file: &tempfile::NamedTempFile) -> usize {
-        let reader = BufReader::new(nt_file.reopen().expect("error opening tmp file"));
-        RdfParser::from_format(NTriples)
-            .for_reader(reader)
-            .collect::<Result<Vec<_>, _>>()
-            .expect("parse nt")
-            .len()
+    /// apple.ttl has 9 distinct triples. Build it through the streaming path and
+    /// confirm both the count and that terms land in HDT dictionary-string form
+    /// (bare IRIs, typed literal keeping its quotes and `^^<datatype>`).
+    #[test]
+    fn ttl_to_hdt() -> Result<(), Error> {
+        let hdt = convert_to_hdt(&["tests/resources/apple.ttl"])?;
+        let triples: HashSet<[String; 3]> = hdt
+            .triples_all()
+            .map(|[s, p, o]| [s.to_string(), p.to_string(), o.to_string()])
+            .collect();
+        assert_eq!(triples.len(), 9);
+        assert!(triples.contains(&[
+            "http://example.org/apple#Apple".to_owned(),
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".to_owned(),
+            "http://example.org/apple#Fruit".to_owned(),
+        ]));
+        assert!(triples.contains(&[
+            "http://example.org/apple#Apple".to_owned(),
+            "http://example.org/apple#isOrganic".to_owned(),
+            "\"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>".to_owned(),
+        ]));
+        Ok(())
     }
 
     #[test]
@@ -187,10 +263,7 @@ mod tests {
             flate2::write::GzEncoder::new(File::create(&gz_path)?, flate2::Compression::default());
         enc.write_all(&source)?;
         enc.finish()?;
-
-        let out = tempfile::Builder::new().suffix(".nt").tempfile()?;
-        convert_to_nt(&[&gz_path], out.reopen()?)?;
-        assert_eq!(count_triples_in(&out), 9);
+        assert_eq!(count_via_convert(&gz_path), 9);
         Ok(())
     }
 
@@ -203,10 +276,7 @@ mod tests {
             bzip2::write::BzEncoder::new(File::create(&bz_path)?, bzip2::Compression::default());
         enc.write_all(&source)?;
         enc.finish()?;
-
-        let out = tempfile::Builder::new().suffix(".nt").tempfile()?;
-        convert_to_nt(&[&bz_path], out.reopen()?)?;
-        assert_eq!(count_triples_in(&out), 9);
+        assert_eq!(count_via_convert(&bz_path), 9);
         Ok(())
     }
 
@@ -223,10 +293,20 @@ mod tests {
   </rdf:Description>
 </rdf:RDF>"#,
         )?;
+        assert_eq!(count_via_convert(&owl_path), 1);
+        Ok(())
+    }
 
-        let out = tempfile::Builder::new().suffix(".nt").tempfile()?;
-        convert_to_nt(&[&owl_path], out.reopen()?)?;
-        assert_eq!(count_triples_in(&out), 1);
+    /// A syntactically invalid file must surface a parse error rather than panic,
+    /// exercising the error-stashing adapter.
+    #[test]
+    fn syntax_error_is_reported() -> Result<(), Error> {
+        let tmp = tempfile::tempdir()?;
+        let bad = tmp.path().join("bad.ttl");
+        // Subject and predicate but no object before the `.` — a Turtle syntax error.
+        std::fs::write(&bad, "<http://example.org/s> <http://example.org/p> .\n")?;
+        let err = convert_to_hdt(&[&bad]).expect_err("expected a parse error");
+        assert!(matches!(err, Error::Parse(_)), "got {err:?}");
         Ok(())
     }
 }

--- a/src/rdf_reader.rs
+++ b/src/rdf_reader.rs
@@ -15,18 +15,20 @@ use std::{
 };
 use url::Url;
 
+const IO_BUF: usize = 1 << 20;
+
 pub(crate) fn convert_to_nt<P: AsRef<Path>>(
     file_paths: &[P],
     output_file: std::fs::File,
 ) -> Result<(), Error> {
-    let mut dest_writer = BufWriter::new(output_file);
+    let mut dest_writer = BufWriter::with_capacity(IO_BUF, output_file);
     for file in file_paths {
         let file = file.as_ref();
         let source = std::fs::File::open(file).map_err(|e| {
             error!("Error opening file {}: {e:?}", file.display());
             e
         })?;
-        let source_reader = BufReader::new(source);
+        let source_reader = BufReader::with_capacity(IO_BUF, source);
 
         debug!("converting {} to nt format", file.display());
 
@@ -89,6 +91,22 @@ pub(crate) fn convert_to_nt<P: AsRef<Path>>(
         debug!("RDF to NTriple convert time: {:?}", v.elapsed());
     }
     dest_writer.flush()?;
+    Ok(())
+}
+
+pub(crate) fn concat_nt<P: AsRef<Path>>(
+    file_paths: &[P],
+    mut output_file: std::fs::File,
+) -> Result<(), Error> {
+    for file in file_paths {
+        let file = file.as_ref();
+        let mut source = std::fs::File::open(file).map_err(|e| {
+            error!("Error opening file {}: {e:?}", file.display());
+            e
+        })?;
+        io::copy(&mut source, &mut output_file)?;
+        output_file.write_all(b"\n")?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Had Claude perform a "What would Theo de Raadt say" code review and addressed some of the findings.

Bumps the `hdt` version to 0.7.3 which includes parallel NT file parsing, and optimizations for single file non-NT RDF inputs using the crates new `from_triples()` function. Mixed RDF is still converted to NT via tempfile. Upstream `hdt` includes massive memory and speed optimizations on the initial RDF-to-HDT conversion